### PR TITLE
Revise default session and reward configuration

### DIFF
--- a/Core Files/DropSim.py
+++ b/Core Files/DropSim.py
@@ -92,7 +92,7 @@ DROP_LEVEL_RANGES = {
 }
 
 STARTING_GEAR_LEVEL = 200            # starting level for all gear pieces
-TOTAL_TIME_HOURS = 4               # simulate for 4 hours (single play session length)
+TOTAL_TIME_HOURS = 10               # simulate for 10 hours (single play session length)
 
 # Default systems configuration - Edge of Fated Leveling & Tiers Rework
 # Updated to match the new system specifications from Google Sheets
@@ -105,17 +105,16 @@ DEFAULT_SYSTEMS = {
         3: lambda: 1,  # Maintained for compatibility but not used in new system
     },
     "fireteam": {
-        # Edge of Fated: Unchanged from previous system
+        # Updated default streak rewards
         1: lambda: 2,
         2: lambda: 3,
-        3: lambda: 4,
+        3: lambda: 3,
     },
     "pinnacle": {
-        # Edge of Fated: Enhanced rewards (increased from 3/4/5 to 4/5/6)
-        # Now includes Dungeons moved from other categories
-        1: lambda: 4,  # Increased from 3
-        2: lambda: 5,  # Increased from 4
-        3: lambda: 6,  # Increased from 5
+        # Updated default streak rewards
+        1: lambda: 3,
+        2: lambda: 4,
+        3: lambda: 4,
     },
 }
 

--- a/Core Files/app.py
+++ b/Core Files/app.py
@@ -9,8 +9,18 @@ app = Flask(__name__, template_folder='.')
 
 # Default configuration values
 DEFAULT_CONFIG = {
-    'total_time_hours': 1.5,
-    'starting_gear_level': 200
+    'total_time_hours': 10,
+    'starting_gear_level': 200,
+    'streak_bonuses': {
+        'solo': {1: 1, 2: 1, 3: 1},
+        'fireteam': {1: 2, 2: 3, 3: 3},
+        'pinnacle': {1: 3, 2: 4, 3: 4}
+    },
+    'drop_ranges': {
+        'solo': [1, 3],
+        'fireteam': [1, 5],
+        'pinnacle': [1, 6]
+    }
 }
 
 def convert_numpy_types(obj):
@@ -43,7 +53,7 @@ def run_simulation():
         config = data.get('config', DEFAULT_CONFIG)
         
         # Extract configuration values
-        total_time_hours = float(config.get('total_time_hours', 1.5))
+        total_time_hours = float(config.get('total_time_hours', 10))
         starting_gear_level = int(config.get('starting_gear_level', 200))
         streak_bonuses = config.get('streak_bonuses')
         drop_ranges = config.get('drop_ranges')
@@ -109,7 +119,7 @@ def compare_systems():
         config = data.get('config', DEFAULT_CONFIG)
         
         # Extract configuration values
-        total_time_hours = float(config.get('total_time_hours', 1.5))
+        total_time_hours = float(config.get('total_time_hours', 10))
         starting_gear_level = int(config.get('starting_gear_level', 200))
         streak_bonuses = config.get('streak_bonuses')
         drop_ranges = config.get('drop_ranges')

--- a/Core Files/index.html
+++ b/Core Files/index.html
@@ -588,7 +588,7 @@
                             </div>
                             <div>
                                 <label class="muted" style="font-size: 0.85em;">Max Drop Level</label>
-                                <input class="input" type="number" id="fireteam_max_drop" value="3" min="0" max="10" step="1">
+                                <input class="input" type="number" id="fireteam_max_drop" value="5" min="0" max="10" step="1">
                             </div>
                         </div>
                     </div>
@@ -603,7 +603,7 @@
                             </div>
                             <div>
                                 <label class="muted" style="font-size: 0.85em;">Max Drop Level</label>
-                                <input class="input" type="number" id="pinnacle_max_drop" value="3" min="0" max="10" step="1">
+                                <input class="input" type="number" id="pinnacle_max_drop" value="6" min="0" max="10" step="1">
                             </div>
                         </div>
                     </div>
@@ -629,7 +629,7 @@
                             </div>
                             <div>
                                 <label class="muted" style="font-size: 0.85em;">Streak 3</label>
-                                <input class="input" type="number" id="fireteam_streak_3" value="4" min="0" max="10" step="1">
+                                <input class="input" type="number" id="fireteam_streak_3" value="3" min="0" max="10" step="1">
                             </div>
                         </div>
                     </div>
@@ -640,15 +640,15 @@
                         <div class="grid grid-3" style="margin-bottom: 10px;">
                             <div>
                                 <label class="muted" style="font-size: 0.85em;">Streak 1</label>
-                                <input class="input" type="number" id="pinnacle_streak_1" value="4" min="0" max="10" step="1">
+                                <input class="input" type="number" id="pinnacle_streak_1" value="3" min="0" max="10" step="1">
                             </div>
                             <div>
                                 <label class="muted" style="font-size: 0.85em;">Streak 2</label>
-                                <input class="input" type="number" id="pinnacle_streak_2" value="5" min="0" max="10" step="1">
+                                <input class="input" type="number" id="pinnacle_streak_2" value="4" min="0" max="10" step="1">
                             </div>
                             <div>
                                 <label class="muted" style="font-size: 0.85em;">Streak 3</label>
-                                <input class="input" type="number" id="pinnacle_streak_3" value="6" min="0" max="10" step="1">
+                                <input class="input" type="number" id="pinnacle_streak_3" value="4" min="0" max="10" step="1">
                             </div>
                         </div>
                     </div>

--- a/Docs/DropSim_Documentation.md
+++ b/Docs/DropSim_Documentation.md
@@ -85,7 +85,7 @@ The **Edge of Fated** system redesigns activities to solve Solo Ops over-efficie
 ### Configurable Settings
 ```python
 STARTING_GEAR_LEVEL = 200         # Starting level for all gear pieces
-TOTAL_TIME_HOURS = 4              # Default simulation duration (4 hours per session)
+TOTAL_TIME_HOURS = 10             # Default simulation duration (10 hours per session)
 ```
 
 ### Drop Level Ranges
@@ -93,8 +93,8 @@ All activity types use the same default drop level ranges:
 ```python
 DROP_LEVEL_RANGES = {
     "solo": (1, 3),        # +1 to +3 levels above character level
-    "fireteam": (1, 3),    # +1 to +3 levels above character level  
-    "pinnacle": (1, 3),    # +1 to +3 levels above character level
+    "fireteam": (1, 5),    # +1 to +5 levels above character level
+    "pinnacle": (1, 6),    # +1 to +6 levels above character level
 }
 ```
 

--- a/api/DropSim.py
+++ b/api/DropSim.py
@@ -92,7 +92,7 @@ DROP_LEVEL_RANGES = {
 }
 
 STARTING_GEAR_LEVEL = 200            # starting level for all gear pieces
-TOTAL_TIME_HOURS = 4               # simulate for 4 hours (single play session length)
+TOTAL_TIME_HOURS = 10               # simulate for 10 hours (single play session length)
 
 # Default systems configuration - Edge of Fated Leveling & Tiers Rework
 # Updated to match the new system specifications from Google Sheets
@@ -105,17 +105,16 @@ DEFAULT_SYSTEMS = {
         3: lambda: 1,  # Maintained for compatibility but not used in new system
     },
     "fireteam": {
-        # Edge of Fated: Unchanged from previous system
+        # Updated default streak rewards
         1: lambda: 2,
         2: lambda: 3,
-        3: lambda: 4,
+        3: lambda: 3,
     },
     "pinnacle": {
-        # Edge of Fated: Enhanced rewards (increased from 3/4/5 to 4/5/6)
-        # Now includes Dungeons moved from other categories
-        1: lambda: 4,  # Increased from 3
-        2: lambda: 5,  # Increased from 4
-        3: lambda: 6,  # Increased from 5
+        # Updated default streak rewards
+        1: lambda: 3,
+        2: lambda: 4,
+        3: lambda: 4,
     },
 }
 

--- a/api/index.py
+++ b/api/index.py
@@ -30,8 +30,18 @@ app = Flask(__name__)
 
 # Default configuration values
 DEFAULT_CONFIG = {
-    'total_time_hours': 1.5,
-    'starting_gear_level': 200
+    'total_time_hours': 10,
+    'starting_gear_level': 200,
+    'streak_bonuses': {
+        'solo': {1: 1, 2: 1, 3: 1},
+        'fireteam': {1: 2, 2: 3, 3: 3},
+        'pinnacle': {1: 3, 2: 4, 3: 4}
+    },
+    'drop_ranges': {
+        'solo': [1, 3],
+        'fireteam': [1, 5],
+        'pinnacle': [1, 6]
+    }
 }
 
 def convert_numpy_types(obj):
@@ -73,7 +83,7 @@ def run_simulation():
         config = data.get('config', DEFAULT_CONFIG)
         
         # Extract configuration values
-        total_time_hours = float(config.get('total_time_hours', 1.5))
+        total_time_hours = float(config.get('total_time_hours', 10))
         starting_gear_level = int(config.get('starting_gear_level', 200))
         streak_bonuses = config.get('streak_bonuses')
         drop_ranges = config.get('drop_ranges')
@@ -142,7 +152,7 @@ def compare_systems():
         config = data.get('config', DEFAULT_CONFIG)
         
         # Extract configuration values
-        total_time_hours = float(config.get('total_time_hours', 1.5))
+        total_time_hours = float(config.get('total_time_hours', 10))
         starting_gear_level = int(config.get('starting_gear_level', 200))
         streak_bonuses = config.get('streak_bonuses')
         drop_ranges = config.get('drop_ranges')

--- a/index.html
+++ b/index.html
@@ -549,7 +549,7 @@
 
                 <div class="form-group">
                     <label for="total_time_hours">Session Length (hours)</label>
-                    <input type="number" id="total_time_hours" value="1.5" min="0.5" max="24" step="0.5">
+                    <input type="number" id="total_time_hours" value="10" min="0.5" max="24" step="0.5">
                 </div>
 
                 <div class="form-group">
@@ -588,7 +588,7 @@
                             </div>
                             <div>
                                 <label class="muted" style="font-size: 0.85em;">Max Drop Level</label>
-                                <input class="input" type="number" id="fireteam_max_drop" value="3" min="0" max="10" step="1">
+                                <input class="input" type="number" id="fireteam_max_drop" value="5" min="0" max="10" step="1">
                             </div>
                         </div>
                     </div>
@@ -603,7 +603,7 @@
                             </div>
                             <div>
                                 <label class="muted" style="font-size: 0.85em;">Max Drop Level</label>
-                                <input class="input" type="number" id="pinnacle_max_drop" value="3" min="0" max="10" step="1">
+                                <input class="input" type="number" id="pinnacle_max_drop" value="6" min="0" max="10" step="1">
                             </div>
                         </div>
                     </div>
@@ -629,7 +629,7 @@
                             </div>
                             <div>
                                 <label class="muted" style="font-size: 0.85em;">Streak 3</label>
-                                <input class="input" type="number" id="fireteam_streak_3" value="4" min="0" max="10" step="1">
+                                <input class="input" type="number" id="fireteam_streak_3" value="3" min="0" max="10" step="1">
                             </div>
                         </div>
                     </div>
@@ -640,15 +640,15 @@
                         <div class="grid grid-3" style="margin-bottom: 10px;">
                             <div>
                                 <label class="muted" style="font-size: 0.85em;">Streak 1</label>
-                                <input class="input" type="number" id="pinnacle_streak_1" value="4" min="0" max="10" step="1">
+                                <input class="input" type="number" id="pinnacle_streak_1" value="3" min="0" max="10" step="1">
                             </div>
                             <div>
                                 <label class="muted" style="font-size: 0.85em;">Streak 2</label>
-                                <input class="input" type="number" id="pinnacle_streak_2" value="5" min="0" max="10" step="1">
+                                <input class="input" type="number" id="pinnacle_streak_2" value="4" min="0" max="10" step="1">
                             </div>
                             <div>
                                 <label class="muted" style="font-size: 0.85em;">Streak 3</label>
-                                <input class="input" type="number" id="pinnacle_streak_3" value="6" min="0" max="10" step="1">
+                                <input class="input" type="number" id="pinnacle_streak_3" value="4" min="0" max="10" step="1">
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- set default session length to 10 hours
- adjust default drop ranges and streak bonuses for fireteam and pinnacle activities
- synchronize documentation and DropSim defaults with new configuration

## Testing
- `python test_local.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7d55260fc8327971bc4db9056c51a